### PR TITLE
Updated mctools.py to read SRV Records

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Linux packages needed for install: python, python-dev, libenchant-dev, libenchan
 CloudBot runs on **Python** *2.7.x*. It is developed on **Ubuntu** *12.04* with **Python** *2.7.3*.
 
 It **requires the Python module** `lXML`, and `Enchant` is needed for the spellcheck plugin.
+It also **requires** `pydns` and is needed for SRV record lookup for the mctools plugin.
 
 The programs `daemon` or `screen` are recomended for the launcher to run optimaly.
 

--- a/plugins/mctools.py
+++ b/plugins/mctools.py
@@ -2,6 +2,7 @@ from util import hook, http
 import socket
 import json
 import struct
+import DNS ## Please remember to install the dependancy 'pydns'
 
 def mccolorconvert(motd):
     empty = ""
@@ -42,6 +43,15 @@ def mcping_connect(host, port):
         return "Error pinging " + host + ":" + str(port) +\
         ", is it up? Double-check your address!"
 
+def srvData(domain):
+    DNS.ParseResolvConf()
+    srv_req = DNS.Request(qtype = 'srv')
+    srv_result = srv_req.req('_minecraft._tcp.%s' % domain)
+
+    for getsrv in srv_result.answers:
+        if getsrv['typename'] == 'SRV':
+            data = [getsrv['data'][2],getsrv['data'][3]]
+            return data
 
 @hook.command(autohelp=False)
 def mclogin(inp, bot=None):
@@ -106,6 +116,7 @@ def mcping(inp):
     "mcping <server>[:port] - Ping a Minecraft server to check status."
     inp = inp.strip().split(" ")[0]
 
+
     if ":" in inp:
         host, port = inp.split(":", 1)
         try:
@@ -113,7 +124,12 @@ def mcping(inp):
         except:
             return "error: invalid port!"
     else:
-        host = inp
-        port = 25565
+        try:
+            getdata = srvData(inp)
+            host = inp
+            port = getdata[0]
+        except: 
+            host = inp
+            port = 25565
     return mccolorconvert(mcping_connect(host, port))
 

--- a/plugins/mctools.py
+++ b/plugins/mctools.py
@@ -126,8 +126,8 @@ def mcping(inp):
     else:
         try:
             getdata = srvData(inp)
-            host = inp
-            port = getdata[0]
+            host = str(getdata[1])
+            port = int(getdata[0])
         except: 
             host = inp
             port = 25565

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 BeautifulSoup==3.2.1
 lxml==3.1beta1
 pyenchant==1.6.5
+pydns>=2.3.6


### PR DESCRIPTION
Updated MC Tools to read SRV Records that were implemented in Minecraft 1.3.1 
Requires module 'pydns' so please run 'sudo pip install pydns'
