### PR TITLE
Add soundcloud autoresponse plugin.

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -34,6 +34,7 @@ if not os.path.exists('config'):
             "wolframalpha": "",
             "lastfm": "",
             "rottentomatoes": "",
+            "soundcloud": "",
             "twitter_consumer_key": "",
             "twitter_consumer_secret": "",
             "twitter_access_token": "",

--- a/plugins/soundc.py
+++ b/plugins/soundc.py
@@ -1,0 +1,18 @@
+from util import hook, http, web
+import soundcloud
+import re
+
+sc_re = (r'(.*:)//(www.)?(soundcloud.com)(.*)', re.I)
+
+@hook.regex(*sc_re)
+def soundcloud_url(match, bot=None):
+  api_key = bot.config.get("api_keys", {}).get("soundcloud")
+  if not api_key:
+    return "Error: no api key set"
+  url = match.group(1).split(' ')[-1] + "//" + (match.group(2) if match.group(2) else "") + match.group(3) + match.group(4).split(' ')[0]
+  client = soundcloud.Client(client_id=api_key)
+  track = client.get('/resolve', url=url)
+  try:
+    return "SoundCloud track: \x02%s\x02 by \x02%s\x02 - \x02%s\x02" % (track.title, track.user['username'], web.isgd(track.permalink_url))
+  except:
+    return "SoundCloud user: \x02%s\x02 - \x02%s\x02" % (track.username, web.isgd(track.permalink_url))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ lxml==3.1beta1
 pyenchant==1.6.5
 pydns>=2.3.6
 BeautifulSoup4
+soundcloud==0.3.6


### PR DESCRIPTION
Currently supports tracks/playlists and users. The /resolve endpoint doesn't send any kind of information about what the item is, except missing items in the response (like .title, which is only in track and playlist responses). So I catch the AttributeError there and switch to returning username instead.
