### PR TITLE
Update help.py

### DIFF
--- a/plugins/help.py
+++ b/plugins/help.py
@@ -13,8 +13,8 @@ def help(inp, say=None, notice=None, input=None, conn=None, bot=None):
         fn = re.match(r'^plugins.(.+).py$', func._filename)
         if fn.group(1).lower() not in disabled:
             if not args.get('adminonly', False) or\
-            input.nick in bot.config["admins"] or\
-            input.mask in bot.config["admins"]:
+            input.nick in bot.config["permission_users"]["admins"] or\
+            input.mask in bot.config["permission_users"]["admins"]:
                 if command not in disabled_comm:
                     if func.__doc__ is not None:
                         if func in funcs:


### PR DESCRIPTION
The new permissions have broken the help.  This patch corrects the help behaviour.

To replicate send .help and you should get the following error:
Unhandled exception in thread started by <function run at 0x7fe5e63018c0>
Traceback (most recent call last):  
  File "core/main.py", line 63, in run  
    out = func(input.inp, **kw)  
  File "plugins/help.py", line 16, in help  
    input.nick in bot.config["admins"] or\  
KeyError: 'admins'

With this patch the help responds as expected.
