### PR TITLE
Fix duration, add new function for timestamp formatting

### DIFF
--- a/plugins/util/timeformat.py
+++ b/plugins/util/timeformat.py
@@ -1,16 +1,14 @@
 def timeformat(seconds):
-    if seconds < 60:
-        timestamp = str(seconds) + "s"
-    elif seconds >= 60 and seconds < 3600:
-        timestamp = "%s:%s" % (seconds/60, seconds%60)
-    elif seconds >= 3600 and seconds < 86400:
-        hours = seconds / 3600
-        seconds = 3600*hours
-        timestamp = "%s:%s:%s" % (hours, seconds/60, seconds%60)
-    elif seconds >= 86400:
-        days = seconds / 86400
-        seconds = 86400*days
-        hours = seconds / 3600
-        seconds = 3600*hours
-        timestamp = "%s days, %s:%s:%s" % (days, hours, seconds/60, seconds%60)
-    return timestamp
+    days = seconds / 86400
+    seconds -= 86400 * days
+    hours = seconds / 3600
+    seconds -= 3600 * hours
+    minutes = seconds / 60
+    seconds -= 60 * minutes
+    if days != 0:
+        return "%s, %02d:%02d:%02d" % (str(days) + " days" if days > 1 else str(days) + " day", hours, minutes, seconds)
+    elif hours == 0 and minutes != 0:
+        return "%02d:%02d" % (minutes, seconds)
+    elif hours == 0 and minutes == 0:
+        return "%02d" % seconds
+    return "%02d:%02d:%02d" % (hours, minutes, seconds)

--- a/plugins/util/timeformat.py
+++ b/plugins/util/timeformat.py
@@ -1,0 +1,16 @@
+def timeformat(seconds):
+    if seconds < 60:
+        timestamp = str(seconds) + "s"
+    elif seconds >= 60 and seconds < 3600:
+        timestamp = "%s:%s" % (seconds/60, seconds%60)
+    elif seconds >= 3600 and seconds < 86400:
+        hours = seconds / 3600
+        seconds = 3600*hours
+        timestamp = "%s:%s:%s" % (hours, seconds/60, seconds%60)
+    elif seconds >= 86400:
+        days = seconds / 86400
+        seconds = 86400*days
+        hours = seconds / 3600
+        seconds = 3600*hours
+        timestamp = "%s days, %s:%s:%s" % (days, hours, seconds/60, seconds%60)
+    return timestamp

--- a/plugins/util/timeformat.py
+++ b/plugins/util/timeformat.py
@@ -6,9 +6,9 @@ def timeformat(seconds):
     minutes = seconds / 60
     seconds -= 60 * minutes
     if days != 0:
-        return "%s, %02d:%02d:%02d" % (str(days) + " days" if days > 1 else str(days) + " day", hours, minutes, seconds)
+        return "%sd %sh %sm %ss" % (days, hours, minutes, seconds)
     elif hours == 0 and minutes != 0:
-        return "%02d:%02d" % (minutes, seconds)
+        return "%sm %ss" % (minutes, seconds)
     elif hours == 0 and minutes == 0:
-        return "%02d" % seconds
-    return "%02d:%02d:%02d" % (hours, minutes, seconds)
+        return "%ss" % seconds
+    return "%sh %sm %ss" % (hours, minutes, seconds)

--- a/plugins/vimeo.py
+++ b/plugins/vimeo.py
@@ -4,18 +4,17 @@ from util import hook, http, timeformat
 @hook.regex(r'vimeo.com/([0-9]+)')
 def vimeo_url(match):
     "vimeo <url> -- returns information on the Vimeo video at <url>"
-    info = http.get_json('http://vimeo.com/api/v2/video/%s.json' % match.group(1))
+    info = http.get_json('http://vimeo.com/api/v2/video/%s.json'
+                         % match.group(1))
 
     if info:
-        info = info[0]
-        return ("\x02{title}\x02 - length \x02{duration}\x02 - "
-                "\x02{likes}\x02 likes - "
-                "\x02{plays}\x02 plays - "
-                "\x02{username}\x02 on \x02{uploaddate}\x02".format(
-                    title=info["title"],
-                    duration=timeformat.timeformat(info["duration"]),
-                    likes=info["stats_number_of_likes"],
-                    plays=info["stats_number_of_plays"],
-                    username=info["user_name"],
-                    uploaddate=info["upload_date"])
-               )
+        info[0]["duration"] = timeformat.timeformat(info[0]["duration"])
+        info[0]["stats_number_of_likes"] = format(
+                    info[0]["stats_number_of_likes"], ",d")
+        info[0]["stats_number_of_plays"] = format(
+                    info[0]["stats_number_of_plays"], ",d")
+        return ("\x02%(title)s\x02 - length \x02%(duration)s\x02 - "
+                "\x02%(stats_number_of_likes)s\x02 likes - "
+                "\x02%(stats_number_of_plays)s\x02 plays - "
+                "\x02%(user_name)s\x02 on \x02%(upload_date)s\x02"
+                % info[0])

--- a/plugins/vimeo.py
+++ b/plugins/vimeo.py
@@ -1,15 +1,21 @@
-from util import hook, http
+from util import hook, http, timeformat
 
 
 @hook.regex(r'vimeo.com/([0-9]+)')
 def vimeo_url(match):
     "vimeo <url> -- returns information on the Vimeo video at <url>"
-    info = http.get_json('http://vimeo.com/api/v2/video/%s.json'
-                         % match.group(1))
+    info = http.get_json('http://vimeo.com/api/v2/video/%s.json' % match.group(1))
 
     if info:
-        return ("\x02%(title)s\x02 - length \x02%(duration)ss\x02 - "
-                "\x02%(stats_number_of_likes)s\x02 likes - "
-                "\x02%(stats_number_of_plays)s\x02 plays - "
-                "\x02%(user_name)s\x02 on \x02%(upload_date)s\x02"
-                % info[0])
+        info = info[0]
+        return ("\x02{title}\x02 - length \x02{duration}\x02 - "
+                "\x02{likes}\x02 likes - "
+                "\x02{plays}\x02 plays - "
+                "\x02{username}\x02 on \x02{uploaddate}\x02".format(
+                    title=info["title"],
+                    duration=timeformat.timeformat(info["duration"]),
+                    likes=info["stats_number_of_likes"],
+                    plays=info["stats_number_of_plays"],
+                    username=info["user_name"],
+                    uploaddate=info["upload_date"])
+               )


### PR DESCRIPTION
Now plugins can use 

```
from util import hook, timeformat

@hook.command
def formattime(inp):
    return timeformat.timeformat(int(inp))
```

which will return `1:40`.
