### PR TITLE
Add catch for git.io assigning the same ID twice, provide alternative custom url

### DIFF
--- a/plugins/github.py
+++ b/plugins/github.py
@@ -60,6 +60,8 @@ def ghissues(inp):
     title = data["title"]
     summary = truncate(data["body"])
     gitiourl = gitio(data["html_url"])
+    if "Failed to get URL" in gitiourl:
+        gitiourl = gitio(data["html_url"] + " " + repo.split("/")[1] + number)
     if summary == "":
       return fmt1 % (number, state, user, title, gitiourl)
     else:


### PR DESCRIPTION
![What the hell, git.io](http://i.imgur.com/oED3qPD.png)
