### PR TITLE
Simplify permissions checking and only print value if user is in group

### DIFF
--- a/plugins/core_sieve.py
+++ b/plugins/core_sieve.py
@@ -38,30 +38,21 @@ def sieve_suite(bot, input, func, kind, args):
         groups = bot.config.get("permissions", [])
 
         allowed_permissions = args.get('permissions', [])
-        allowed_groups = []
-
-        # loop over every group
-        for key, value in groups.iteritems():
-            # loop over every permission the command allows
-            for permission in allowed_permissions:
-                # see if the group has that permission
-                print value
-                if permission in value["perms"]:
-                    # if so, add the group name to the allowed_groups list
-                    allowed_groups.append(key)
-
-        if not allowed_groups:
-            print "Something is wrong. A hook requires {} but" \
-                  " there are no groups with that permission!".format(str(allowed_permissions))
 
         mask = input.mask.lower()
 
-        for group in allowed_groups:
-            group_users = bot.config.get("permissions", {}).get(group, [])["users"]
-            group_users = [_mask.lower() for _mask in group_users]
-            for pattern in group_users:
-                if fnmatch(mask, pattern):
-                    return input
+        # loop over every group
+        for key, group in groups.iteritems():
+            # loop over every permission the command allows
+            for permission in allowed_permissions:
+                # see if the group has that permission
+                if permission in group["perms"]:
+                    # if so, check it
+                    group_users = [_mask.lower() for _mask in group["users"]]
+                    for pattern in group_users:
+                        if fnmatch(mask, pattern):
+                            print "Allowed group {}.".format(group)
+                            return input
 
         input.notice("Sorry, you are not allowed to use this command.")
         return None


### PR DESCRIPTION
Although this removes the 'there are no groups with that permission' message, it simplifies permissions checking by removing storing the allowed groups in an array, and instead just iterating over the users inside the loop iterating over the groups.

This will also make the bot print out when a group is found with the permission with the user in it, rather than when any group with the permission is found.
