### PR TITLE
Add support for multiple channels to .join and .leave

### DIFF
--- a/plugins/admin.py
+++ b/plugins/admin.py
@@ -138,8 +138,11 @@ def clearlogs(inp, input=None):
 @hook.command(permissions=["botcontrol"])
 def join(inp, conn=None, notice=None):
     """join <channel> -- Joins <channel>."""
-    notice("Attempting to join {}...".format(inp))
-    conn.join(inp)
+    for target in inp.split(" "):
+        if not target.startswith("#"):
+            target = "#{}".format(target)
+        notice("Attempting to join {}...".format(target))
+        conn.join(target)
 
 
 @hook.command(autohelp=False, permissions=["botcontrol"])
@@ -148,11 +151,14 @@ def part(inp, conn=None, chan=None, notice=None):
     If [channel] is blank the bot will leave the
     channel the command was used in."""
     if inp:
-        target = inp
+        targets = inp
     else:
-        target = chan
-    notice("Attempting to leave {}...".format(target))
-    conn.part(target)
+        targets = chan
+    for target in targets.split(" "):
+        if not target.startswith("#"):
+            target = "#{}".format(target)
+        notice("Attempting to leave {}...".format(target))
+        conn.part(target)
 
 
 @hook.command(autohelp=False, permissions=["botcontrol"])


### PR DESCRIPTION
This commit will allow you to use .join or .leave with the following syntax:

```
.join channel1 channel2 #channel3 channel4
.leave #channel1 channel2 channel3 #channel4
```

The bot will add # to the start of each channel if it doesn't start with it.

This makes joining or leaving a lot of channels a lot easier, and it doesn't interfere with just using one channel.
