### PR TITLE
Fix the correction plugin

### DIFF
--- a/plugins/correction.py
+++ b/plugins/correction.py
@@ -17,10 +17,10 @@ def correction(inp, message=None, input=None, notice=None, db=None):
         replace = splitinput[2]
         if find in last_message[1]:
             if "\x01ACTION" in last_message[1]:
-                message = last_message[1].replace("\x01ACTION ", "/me ").replace("\x01", "")
+                msg = last_message[1].replace("\x01ACTION ", "/me ").replace("\x01", "")
             else:
-                message = last_message[1]
-            message(u"{} meant to say: {}".format(message.replace(find, "\x02" + replace + "\x02"), nick))
+                msg = last_message[1]
+            message(u"Correction, <{}> {}".format(nick, msg.replace(find, "\x02" + replace + "\x02")))
         else:
             notice(u"{} can't be found in your last message".format(find))
     else:


### PR DESCRIPTION
Currently correction is broken, due to setting the 'message' variable to the actual message, instead of leaving it as the message function.

This will change it to set 'msg' instead of 'message', so 'message' stays as the message function.
