### PR TITLE
Created plugin to parse Google urls to normal urls

### DIFF
--- a/plugins/googleurlparse.py
+++ b/plugins/googleurlparse.py
@@ -1,0 +1,16 @@
+from util import hook
+from urllib import unquote
+
+@hook.command(autohelp=False)
+def googleurl(inp, db=None, input=None):
+    """googleurl [nickname] - Converts Google urls (google.com/url) to normal urls where possible, in the specified nickname's last message. If nickname isn't provided, action will be performed on user's last message"""
+    if not inp:
+        inp = input.nick
+    last_message = db.execute("select name, quote from seen_user where name"
+                              " like ? and chan = ?", (inp.lower(), input.chan.lower())).fetchone()
+    if last_message:
+        msg = last_message[1]
+        out = ", ".join([(unquote(a[4:]) if a[:4] == "url=" else "") for a in msg.split("&")]).replace(", ,", "").strip()
+        return out if out else "No matches in your last message."
+    else:
+        return "You haven't said anything in this channel yet!" if inp == input.nick else "That user hasn't said anything in this channel yet!"


### PR DESCRIPTION
Example Google url: http://www.google.nl/url?sa=i&rct=j&q=&esrc=s&source=images&cd=&cad=rja&docid=kzd-kV9_31JsiM&tbnid=7Sl4EuqcSGY2wM:&ved=0CAIQjBw&url=http%3A%2F%2F4sysops.com%2Fwp-content%2Fuploads%2F2011%2F02%2FFTP.client.for_.the_.Windows.command.line_.FTPUse.gif&ei=2ujvUta0BKrV0QWdj4DoDg&bvm=bv.60444564,d.d2k&psig=AFQjCNEI_OCuyO1vWor1SoK_i5QGQYaY-Q&ust=1391540811442407
Example output url: http://4sysops.com/wp-content/uploads/2011/02/FTP.client.for_.the_.Windows.command.line_.FTPUse.gif
