### PR TITLE
Fix xkcd comics made in January throwing an error

### DIFF
--- a/plugins/xkcd.py
+++ b/plugins/xkcd.py
@@ -4,7 +4,7 @@ from util import hook, http
 
 
 xkcd_re = (r'(.*:)//(www.xkcd.com|xkcd.com)(.*)', re.I)
-months = {'1': 'January', 2: 'February', 3: 'March', 4: 'April', 5: 'May', 6: 'June', 7: 'July', 8: 'August',
+months = {1: 'January', 2: 'February', 3: 'March', 4: 'April', 5: 'May', 6: 'June', 7: 'July', 8: 'August',
           9: 'September', 10: 'October', 11: 'November', 12: 'December'}
 
 


### PR DESCRIPTION
**The issue**:
Previously, any commit written in January would throw an error because the array key for January was falsely '1' instead of the integer 1. This would lead to the month name not being found and the error occuring.

**PR Breakdown:**
This PR fixes that problem by changing the key of January to the integer 1.

**How to reproduce:**
Ask your CloudBot to `xkcd Regular Expressions`, an error will be shown in console.

I did not check if this still compiles because the change is so small that it is very improbable that it could cause problems. Also I edited the exact same thing on my bot and it worked.
If testing is required anyway, I'll test it at request.
