### PR TITLE
Update tell.py to support multiple connections

### DIFF
--- a/plugins/tell.py
+++ b/plugins/tell.py
@@ -6,19 +6,18 @@ import re
 
 from util import hook, timesince
 
-db_ready = False
+db_ready = []
 
-def db_init(db):
-    """check to see that our db has the tell table and return a dbection."""
+
+def db_init(db, conn):
+    """Check that our db has the tell table, create it if not."""
     global db_ready
-    if not db_ready:
+    if not conn.name in db_ready:
         db.execute("create table if not exists tell"
                    "(user_to, user_from, message, chan, time,"
                    "primary key(user_to, message))")
         db.commit()
-        db_ready = True
-
-    return db
+        db_ready.append(conn.name)
 
 
 def get_tells(db, user_to):
@@ -29,11 +28,11 @@ def get_tells(db, user_to):
 
 @hook.singlethread
 @hook.event('PRIVMSG')
-def tellinput(paraml, input=None, notice=None, db=None, bot=None, nick=None, conn=None):
+def tellinput(inp, input=None, notice=None, db=None, nick=None, conn=None):
     if 'showtells' in input.msg.lower():
         return
 
-    db_init(db)
+    db_init(db, conn)
 
     tells = get_tells(db, nick)
 
@@ -53,10 +52,10 @@ def tellinput(paraml, input=None, notice=None, db=None, bot=None, nick=None, con
 
 
 @hook.command(autohelp=False)
-def showtells(inp, nick='', chan='', notice=None, db=None):
+def showtells(inp, nick='', chan='', notice=None, db=None, conn=None):
     """showtells -- View all pending tell messages (sent in a notice)."""
 
-    db_init(db)
+    db_init(db, conn)
 
     tells = get_tells(db, nick)
 
@@ -75,7 +74,7 @@ def showtells(inp, nick='', chan='', notice=None, db=None):
 
 
 @hook.command
-def tell(inp, nick='', chan='', db=None, input=None, notice=None):
+def tell(inp, nick='', chan='', db=None, input=None, notice=None, conn=None):
     """tell <nick> <message> -- Relay <message> to <nick> when <nick> is around."""
     query = inp.split(' ', 1)
 
@@ -100,10 +99,10 @@ def tell(inp, nick='', chan='', db=None, input=None, notice=None):
         return
 
     if not re.match("^[A-Za-z0-9_|.\-\]\[]*$", user_to.lower()):
-        notice("I cant send a message to that user!")
+        notice("I can't send a message to that user!")
         return
 
-    db_init(db)
+    db_init(db, conn)
 
     if db.execute("select count() from tell where user_to=?",
                   (user_to,)).fetchone()[0] >= 10:


### PR DESCRIPTION
**The issue:**
Currently, if you have your CloudBot connected to multiple networks, the tell command and its PRIVMSG event hooks do only initialize their database connection (aka. create the necessary table if it does not exist) when it has not been initialized. The initialization state is stored in a global boolean db_ready. 
However, if you have multiple connections, the table is created for the first connection the bot receives a message on, but other connections' databases _are not checked_. So, suppose you have two connections, c1 and c2. The bot does the following:

```
Receives message from c1, checks db_ready (is False) -> Creates table, Sets db_ready = True
Receives message from c2, checks db_ready (is True) -> Fails with "table does not exist"!
```

**What this does:**
This PR resolves above issue by storing whether the database is ready _per connection_. It does that by changing db_ready to a list and adding every initialized (i.e. table was created) connection's name to it. 
Instead of checking for `not db_ready`, it checks `conn.name in db_ready`. 
So our previous example would look like this:

```
Receives message from c1, checks db_ready contains c1 (False) -> Creates table, Adds c1
Receives message from c2, checks db_ready contains c2 (False) -> Creates table, Adds c2
```

This also changes a (unused) parameter name from `paraml` to `inp` (shorthand for input), because I think that fits better what it does.

It also adds a missing apostrophe to a message (Changes from `cant` to `can't`)

**How to reproduce:**
Clone a new CloudBot. Add two networks to your config file. Write a message on the first connection and then on the other connection. The second time, a stack trace is printed with a `table does not exist` error. (2 tell commands should also work for reproducing)

This exact patch is currently being run on my bot and no issues have occurred.

_If the text of this PR seems familiar to you, I have copied the one from #209 (and adapted it for this change) because the issue and solution are nearly exactly the same._

Thank you!

**Update 19:47:**
In case you were wondering, I removed the `return db` from `db_init` because the return value is never used.
