### PR TITLE
Use unicode string for returned message in geoip

### DIFF
--- a/plugins/geoip.py
+++ b/plugins/geoip.py
@@ -51,4 +51,4 @@ def geoip(inp):
     data["cc"] = record["country_code"] or "N/A"
     data["country"] = record["country_name"] or "Unknown"
     data["city"] = record["city"] or "Unknown"
-    return "\x02Country:\x02 {country} ({cc}), \x02City:\x02 {city}{region}".format(**data)
+    return u"\x02Country:\x02 {country} ({cc}), \x02City:\x02 {city}{region}".format(**data)


### PR DESCRIPTION
When using the geoip command on an IP in a location that contains non ascii characters, an exception is thrown. This commit fixes that.

Test case: 
    .geoip bhs.proof.ovh.net 
Should result with:
    Country: Canada (CA), City: Montréal
