### PR TITLE
Fix unicode support for wikipedia

### DIFF
--- a/plugins/wikipedia.py
+++ b/plugins/wikipedia.py
@@ -42,8 +42,8 @@ def wiki(inp):
     if title.lower() not in desc.lower():
         desc = title + desc
 
-    desc = re.sub('\s+', ' ', desc).strip()  # remove excess spaces
+    desc = u' '.join(desc.split())  # remove excess spaces
 
     desc = text.truncate_str(desc, 200)
 
-    return '{} :: {}'.format(desc, http.quote(url, ':/'))
+    return u'{} :: {}'.format(desc, http.quote(url, ':/'))


### PR DESCRIPTION
`.wiki` will throw errors when looking up a definition which contains a non-ascii character. Example:

```
16:51:42 #test <Dabo> .wiki mojang
Unhandled exception in thread started by <function run at 0x7faf6e6cc8c0>
Traceback (most recent call last):
  File "core/main.py", line 70, in run
    out = func(input.inp)
  File "plugins/wikipedia.py", line 49, in wiki
    return '{} :: {}'.format(desc, http.quote(url, ':/'))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe4' in position 14: ordinal not in range(128)
```
