### PR TITLE
Fix unicode support for dictionary.py

### DIFF
--- a/plugins/dictionary.py
+++ b/plugins/dictionary.py
@@ -19,10 +19,10 @@ def define(inp):
                          '//div[@class="example"]')
 
     if not definition:
-        return 'No results for ' + inp + ' :('
+        return u'No results for {} :('.format(inp)
 
     def format_output(show_examples):
-        result = '{}: '.format(h.xpath('//dt[@class="title-word"]/a/text()')[0])
+        result = u'{}: '.format(h.xpath('//dt[@class="title-word"]/a/text()')[0])
 
         correction = h.xpath('//span[@class="correct-word"]/text()')
         if correction:
@@ -77,7 +77,7 @@ def etymology(inp):
     etym = h.xpath('//dl')
 
     if not etym:
-        return 'No etymology found for {} :('.format(inp)
+        return u'No etymology found for {} :('.format(inp)
 
     etym = etym[0].text_content()
 


### PR DESCRIPTION
`.define` and `.e` will throw errors when there are either definitions containing non-ascii characters, or it couldn't find input with a non-ascii character in it. This patch fixes that.

Examples:

```
17:24:03 #test <Dabo> .dictionary touché
Unhandled exception in thread started by <function run at 0x7fcb2db458c0>
Traceback (most recent call last):
  File "core/main.py", line 70, in run
    out = func(input.inp)
  File "plugins/dictionary.py", line 57, in define
    result = format_output(True)
  File "plugins/dictionary.py", line 25, in format_output
    result = '{}: '.format(h.xpath('//dt[@class="title-word"]/a/text()')[0])
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 5: ordinal not in range(128)
17:25:39 #test <Dabo> .e é
Unhandled exception in thread started by <function run at 0x7ff50c8eb8c0>
Traceback (most recent call last):
  File "core/main.py", line 70, in run
    out = func(input.inp)
  File "plugins/dictionary.py", line 80, in etymology
    return 'No etymology found for {} :('.format(inp)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 0: ordinal not in range(128)
```
