### PR TITLE
Rework cloudbot.py

### DIFF
--- a/cloudbot.py
+++ b/cloudbot.py
@@ -53,6 +53,8 @@ class CloudBotWrapper():
                 if self.cloudbot.do_restart:
                     # create a new bot thread and start it
                     del self.cloudbot
+                    print("Restarting")
+                    time.sleep(1)  # sleep one second for timeouts
                     self.cloudbot = bot.CloudBot()
                     self.cloudbot.start()
                     continue

--- a/cloudbot.py
+++ b/cloudbot.py
@@ -1,10 +1,11 @@
-#!/usr/bin/env python
-from core import bot
-
+#!/usr/bin/env python3
 import os
 import sys
 import time
 import signal
+
+from core import bot
+
 
 # check python version 
 if sys.version_info < (3, 2, 0):
@@ -16,37 +17,50 @@ os.chdir(sys.path[0] or '.')  # do stuff relative to the install directory
 
 # this is not the code you are looking for
 if os.path.exists(os.path.abspath('lib')):
-    sys.path += ['lib'] 
+    sys.path += ['lib']
 
 print('CloudBot3 <http://git.io/cloudbotirc>')
 
 
-def exit_gracefully(signum, frame):
-    # this doesn't really work at all
-    cloudbot.stop()
+class CloudBotWrapper():
+    def __init__(self):
+        # create the master cloudbot
+        self.cloudbot = bot.CloudBot()
 
-    # restore the original handler so if they do it again it triggers
-    signal.signal(signal.SIGINT, original_sigint)
+        self.original_sigint = None
 
-# store the original SIGINT handler
-original_sigint = signal.getsignal(signal.SIGINT)
-signal.signal(signal.SIGINT, exit_gracefully)
+    def set_signals(self):
+        # store the original SIGINT handler
+        self.original_sigint = signal.getsignal(signal.SIGINT)
+        signal.signal(signal.SIGINT, self.exit_gracefully)
 
-# create a bot master and start it
-cloudbot = bot.CloudBot()
-cloudbot.start()
+    def exit_gracefully(self, signum, frame):
+        # this doesn't really work at all
+        self.cloudbot.stop()
 
-# watch to see if the bot stops running or needs a restart
-while True:
-    if cloudbot.running:
-        time.sleep(.1)
-    else:
-        if cloudbot.do_restart:
-            # create a new bot thread and start it
-            # Todo: Make this work
-            del cloudbot
-            cloudbot = bot.Bot()
-            cloudbot.start()
-            continue
-        else:
-            break
+        # restore the original handler so if they do it again it triggers
+        signal.signal(signal.SIGINT, self.original_sigint)
+
+    def run(self):
+        # start the bot master
+        self.cloudbot.start()
+
+        # watch to see if the bot stops running or needs a restart
+        while True:
+            if self.cloudbot.running:
+                time.sleep(.1)
+            else:
+                if self.cloudbot.do_restart:
+                    # create a new bot thread and start it
+                    del self.cloudbot
+                    self.cloudbot = bot.CloudBot()
+                    self.cloudbot.start()
+                    continue
+                else:
+                    break
+
+
+if __name__ == "__main__":
+    main_wrapper = CloudBotWrapper()
+    main_wrapper.set_signals()
+    main_wrapper.run()


### PR DESCRIPTION
This patch reworks cloudbot.py to use a 'CloudBotWrapper' class, instead of just having everything outside of classes. This also makes it so cloudbot.py won't run if `__name__ != "__main__"` for support with documentation creation and stuff like that.

This also, along with the other PRs currently open to refresh, fix restarting support for the bot.
