### PR TITLE
Update and format main.py

### DIFF
--- a/plugins/log.py
+++ b/plugins/log.py
@@ -49,7 +49,7 @@ def gmtime(format):
 
 def beautify(input):
     format = formats.get(input.command, '%(raw)s')
-    args = dict(input)
+    args = input.__dict__
 
     leng = len(args['paraml'])
     for n, p in enumerate(args['paraml']):
@@ -92,6 +92,10 @@ def get_log_fd(dir, server, chan):
 #@hook.singlethread
 @hook.event('*')
 def log(paraml, input=None, bot=None):
+    """
+
+    :type bot: core.bot.CloudBot
+    """
     timestamp = gmtime(timestamp_format)
 
     fd = get_log_fd(bot.data_dir, input.server, 'raw')


### PR DESCRIPTION
Reworks the Input class to not be a dict, instead be a regular object. This means that you can't do input["conn"], but I don't see a need to.

This also changes the `dict(input)` to `input.__dict__` in the log.py plugin. This fixes it when Input isn't a dict, I'm not sure why though.

Changes the complicated double-negative autohelp statement in dispatch to something that makes more sense:

```
-    if not (not autohelp or not args.get('autohelp', True) or input.inp or not (func.__doc__ is not None)):
+    if autohelp and args.get('autohelp', True) and not input.text and func.__doc__ is not None:
```

Adds type specifications in all function documentation.

Adds a more complicated argument checker for plugin functions, that supports both the new and the old plugin format.
