### PR TITLE
Implement more PermissionManager methods

### DIFF
--- a/core/irc.py
+++ b/core/irc.py
@@ -267,6 +267,9 @@ class BotConnection(object):
         self.input_queue = queue.Queue()
         self.output_queue = queue.Queue()
 
+        # create permissions manager
+        self.permissions = PermissionManager(self)
+
         # create the IRC connection and connect
         self.connection = self.create_connection()
         self.connection.connect()
@@ -281,9 +284,6 @@ class BotConnection(object):
                                         self.parsed_queue)
         self.parse_thread.daemon = True
         self.parse_thread.start()
-
-        # create permissions manager
-        self.permissions = PermissionManager(bot, self)
 
     def create_connection(self):
         if self.ssl:


### PR DESCRIPTION
Implement a lot more permissions methods.

Also, makes PermissionManager send warnings on upper-case group names, and only need conn (not bot) in constructor.

Note that due to modifying core/irc.py, this patch is incompatible with #252. It shouldn't be that hard to work out, and if you pull one, I'll fix the other one.
