### PR TITLE
Fix http.get_json

### DIFF
--- a/util/http.py
+++ b/util/http.py
@@ -31,7 +31,7 @@ jar = http.cookiejar.CookieJar()
 
 
 def get(*args, **kwargs):
-    return open(*args, **kwargs).read()
+    return open(*args, **kwargs).read().decode()
 
 
 def get_url(*args, **kwargs):


### PR DESCRIPTION
Makes the http util's 'get' function decode the text into a string. This fixes the get_json function (and probably others as well).
