### PR TITLE
Make correction plugin case-insensitive

### DIFF
--- a/plugins/correction.py
+++ b/plugins/correction.py
@@ -1,10 +1,18 @@
+import re
+
 from util import hook
 
-CORRECTION_RE = r'^(s|S)/.*/.*/?\S*$'
+
+CORRECTION_RE = r'^[sS]/.*/.*/?\S*$'
 
 
 @hook.regex(CORRECTION_RE)
 def correction(match, input=None, conn=None, message=None):
+    """
+    :type match: re.__Match
+    :type input: core.main.Input
+    :type conn: core.irc.BotConnection
+    """
     split = input.msg.split("/")
 
     if len(split) == 4:
@@ -13,6 +21,7 @@ def correction(match, input=None, conn=None, message=None):
         nick = None
 
     find = split[1]
+    find_re = re.compile("(?i){}".format(re.escape(find)))
     replace = split[2]
 
     for item in conn.history[input.chan].__reversed__():
@@ -23,10 +32,10 @@ def correction(match, input=None, conn=None, message=None):
         if nick:
             if nick != name.lower():
                 continue
-        if find in msg:
+        if find_re.search(msg):
             if "\x01ACTION" in msg:
                 msg = msg.replace("\x01ACTION ", "/me ").replace("\x01", "")
-            message("Correction, <{}> {}".format(name, msg.replace(find, "\x02" + replace + "\x02")))
+            message("Correction, <{}> {}".format(name, find_re.sub("\x02" + replace + "\x02", msg)))
             return
         else:
             continue


### PR DESCRIPTION
Makes the correction use an (escaped) case-insensitive regex instead of str.replace
