### PR TITLE
Fix urlnorm normalize for python 3

### DIFF
--- a/util/urlnorm.py
+++ b/util/urlnorm.py
@@ -80,7 +80,9 @@ def normalize(url, assume_scheme=False):
     # Always use uppercase A-through-F characters when percent-encoding.
     # All portions of the URI must be utf-8 encoded NFC from Unicode strings
     def clean(string):
-        string = str(unquote(string), 'utf-8', 'replace')
+        string = unquote(string)
+        if isinstance(string, bytes):
+            string = string.decode('utf-8', 'replace')
         return unicodedata.normalize('NFC', string).encode('utf-8')
 
     path = quote(clean(path), "~:/?#[]@!$&'()*+,;=")


### PR DESCRIPTION
Don't assume the string is bytes
