### PR TITLE
tell.py: Clarify on an ambiguous message, and remove a little bit of redundancy in a regular expression.

### DIFF
--- a/plugins/tell.py
+++ b/plugins/tell.py
@@ -98,7 +98,7 @@ def tell(inp, nick='', chan='', db=None, input=None, notice=None, conn=None):
         notice("Thanks for the message, {}!".format(user_from))
         return
 
-    if not re.match("^[A-Za-z0-9_|.\-\]\[]*$", user_to.lower()):
+    if not re.match("^[a-z0-9_|.\-\]\[]*$", user_to.lower()):
         notice("I can't send a message to that user!")
         return
 
@@ -118,4 +118,4 @@ def tell(inp, nick='', chan='', db=None, input=None, notice=None, conn=None):
         notice("Message has already been queued.")
         return
 
-    notice("Your message has been sent!")
+    notice("Your message has been saved, and {} will be notified once they are active.".format(user_to))


### PR DESCRIPTION
This pull request does two very small things, both are affiliated with `tell.py`

The message that was sent implied that the user would receive the message
  instantaneously, which is not the case, as they only get the message
  the moment they speak.

The regular expression matched A-Z when the string was lowercase, making it a redundant check, it has been corrected.

Although the changes are small, I took the liberty to test my changes anyhow as I am rather new to Python, but I've confirmed the changes work and verified in `#cloudbot` if it looked fine.
