### PR TITLE
Adds "armoury", a command which interacts with the World of Warcraft Armoury API

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,6 +16,7 @@ mikeleigh
 Spudstabber
 frozenMC
 frdmn
+Zarthus
 
 
 

--- a/plugins/wow.py
+++ b/plugins/wow.py
@@ -1,0 +1,131 @@
+"""
+wow.py: 
+Written by Zarthus <zarthus@zarth.us> May 30, 2014.
+Gets data from the World of Warcraft Armoury API
+
+Commands:
+armoury, armory: Request data from the armoury API and format it into something human readable.
+
+Revision 0
+"""
+
+import re 
+import json
+from util import hook, http, web
+
+@hook.command('armory')
+@hook.command
+def armoury(inp):
+    """armoury  [realm] [character name] [region = EU] - Look up character and returns API data."""
+
+    # Splits the input, builds the API url, and returns the formatted data to user.
+    splitinput = inp.lower().split()
+
+    if len(splitinput) < 2:
+        return 'armoury [realm] [character name] [region = EU] - Look up character and returns API data.'
+        
+    realm = splitinput[0]
+    charname = splitinput[1]
+    
+    if len(splitinput) < 3:
+        region = 'eu'
+    else:
+        region = splitinput[2]
+        
+    if not re.match("^[a-z]{1,3}$", region):
+        return 'The region specified is not a valid region. Valid regions: eu, us, sea, kr, tw.'
+
+    if not re.match("^[\d!@#$%^&*()_+]$", charname) or len(charname) > 18: 
+        # May not contain digits, or repeat the same letter three times, or contain !@#%^&()_+[]. 
+        # Special characters are permitted, such as áéíóßø.nano
+        return 'The character name is not a valid name. Character names can only contain letters, and be 18 characters long.'
+    
+    if not re.match("^[a-z]{3,32}$", realm):
+        return 'The realm name is not a valid name. Realm names can only contain letters.'
+    
+    region_short = wow_region_shortname(region)
+
+    if not region_short:
+        return 'The region "{}" is not supported.'.format(region)
+
+    link = "http://{0}.battle.net/api/wow/character/{1}/{2}".format(region, realm, charname)
+    
+    return wow_armoury_data(link)
+        
+def wow_armoury_data(link):
+    """Sends the API request, and returns the data accordingly (in json if raw, nicely formatted if not)."""
+    try:    
+        data = http.get_json(link)
+    except Exception as e:
+        return 'Could not fetch data for {}, error: {}'.format(link, str(e))
+        
+    return wow_armoury_format(data, link)
+
+def wow_armoury_format(data, link):
+    """Format armoury data into a human readable string"""
+
+    if len(data) == 0: 
+        return 'Could not find any results.'
+        
+    if 'reason' in data:
+        # Something went wrong (i.e. realm does not exist, character does not exist, or page not found).
+        return data['reason']
+        
+    if 'name' in data:
+        try:
+            niceurl = link.replace('/api/wow/', '/wow/en/') + '/simple'
+            
+            return '{0} is a level \x0307{1}\x0F {2} {3} on {4} with \x0307{5}\x0F achievement points and \x0307{6}\x0F honourable kills. Armoury Profile: {7}' \
+                .format(data['name'], data['level'], wow_get_gender(data['gender']), wow_get_class(data['class'], True), data['realm'], 
+                data['achievementPoints'], data['totalHonorableKills'], web.isgd(niceurl))
+        except Exception as e:
+            return 'An error occured within the API request for {}, error: {}'.format(link, str(e))
+            
+    return 'An unexpected error occured.'
+    
+def wow_get_gender(genderid):
+    """Formats a gender ID to a readable gender name""" 
+    gender = 'unknown'
+
+    if genderid == 0:
+        gender = 'male'
+    elif genderid == 1: 
+        gender = 'female'
+
+    return gender
+        
+def wow_get_class(classid, colours = False):
+    """Formats a class ID to a readable name, data from http://eu.battle.net/api/wow/data/character/classes"""
+    if colours:
+        classids = {1: "\x0305Warrior\x0F", 2: "\x0313Paladin\x0F", 3: "\x0303Hunter\x0F", 4: "\x0308Rogue\x0F", 5: "Priest", 6: "\x0304Death Knight\x0F", 
+            7: "\x0310Shaman\x0F", 8: "\x0311Mage\x0F", 9: "\x0306Warlock\x0F", 10: "\x0309Monk\x0F", 11: "\x0307Druid\x0F"}
+    else:
+        classids = {1: "Warrior", 2: "Paladin", 3: "Hunter", 4: "Rogue", 5: "Priest", 6: "Death Knight", 7: "Shaman",
+            8: "Mage", 9: "Warlock", 10: "Monk", 11: "Druid"}
+        
+            
+    if classid in classids:
+        return classids[classid]
+    else:
+        return 'unknown'    
+        
+def wow_get_race(raceid):
+    """Formats a race ID to a readable race name, data from http://eu.battle.net/api/wow/data/character/races"""
+    raceids = {1: "Human", 2: "Orc", 3: "Dwarf", 4: "Night Elf", 5: "Undead", 6: "Tauren", 7: "Gnome", 
+        8: "Troll", 9: "Goblin", 10: "Blood Elf", 11: "Draenei", 22: "Worgen", 24: "Pandaren (neutral)", 
+        25: "Pandaren (alliance)", 26: "Pandaren (horde)"}
+
+    if raceid in raceids:
+        return raceids[raceid]
+    else:
+        return 'unknown'
+    
+def wow_region_shortname(region):
+    """Returns a short region name, which functions as battle.net their subdomain (i.e. eu.battle.net)"""
+    validregions = {'eu': 'eu', 'europe': 'eu', 'us': 'us', 'sea': 'sea', 'asia': 'sea', 'kr': 'kr', 'korea': 'kr',
+        'tw': 'tw', 'taiwan': 'tw'}
+
+    if region in validregions:
+        return validregions[region]
+    else:
+        return False

--- a/plugins/wow.py
+++ b/plugins/wow.py
@@ -5,8 +5,6 @@ Gets data from the World of Warcraft Armoury API
 
 Commands:
 armoury, armory: Request data from the armoury API and format it into something human readable.
-
-Revision 0
 """
 
 import re 
@@ -23,30 +21,32 @@ def armoury(inp):
 
     if len(splitinput) < 2:
         return 'armoury [realm] [character name] [region = EU] - Look up character and returns API data.'
-        
-    realm = splitinput[0]
-    charname = splitinput[1]
     
+    realm = splitinput[0].replace('_', '-')
+    charname = splitinput[1]
+
+    # Sets the default region to EU if none specified.
     if len(splitinput) < 3:
         region = 'eu'
     else:
         region = splitinput[2]
-        
-    if not re.match("^[a-z]{1,3}$", region):
+            
+    if not re.match(r"^[a-z]{1,3}$", region):
         return 'The region specified is not a valid region. Valid regions: eu, us, sea, kr, tw.'
 
-    if not re.match("^[\d!@#$%^&*()_+]$", charname) or len(charname) > 18: 
-        # May not contain digits, or repeat the same letter three times, or contain !@#%^&()_+[]. 
-        # Special characters are permitted, such as áéíóßø.nano
-        return 'The character name is not a valid name. Character names can only contain letters, and be 18 characters long.'
+    if re.match(r"^[^\d]$", charname) or len(charname) > 18: 
+        # May not contain digits, repeat the same letter three times, or contain non-word characters. 
+        # Special characters are permitted, such as áéíóßø. 
+        return 'The character name is not a valid name. Character names can only contain letters, special characters, and be 18 characters long.'
     
-    if not re.match("^[a-z]{3,32}$", realm):
-        return 'The realm name is not a valid name. Realm names can only contain letters.'
+    if not re.match(r"^[a-z' _-]{3,32}$", realm):
+		# Realm names can have spaces in them, use dashes for this.
+        return 'The realm name is not a valid name. Realm names can only contain letters, dashes, and apostrophes, up to 32 characters'
     
     region_short = wow_region_shortname(region)
 
     if not region_short:
-        return 'The region "{}" is not supported.'.format(region)
+        return 'The region \'{}\' does not exist.'.format(region)
 
     link = "http://{0}.battle.net/api/wow/character/{1}/{2}".format(region, realm, charname)
     
@@ -57,7 +57,7 @@ def wow_armoury_data(link):
     try:    
         data = http.get_json(link)
     except Exception as e:
-        return 'Could not fetch data for {}, error: {}'.format(link, str(e))
+        return 'Unable to fetch information for {}. Does the realm or character exist? ({})'.format(link, str(e))
         
     return wow_armoury_format(data, link)
 
@@ -72,14 +72,14 @@ def wow_armoury_format(data, link):
         return data['reason']
         
     if 'name' in data:
+        niceurl = link.replace('/api/wow/', '/wow/en/') + '/simple'
+
         try:
-            niceurl = link.replace('/api/wow/', '/wow/en/') + '/simple'
-            
             return '{0} is a level \x0307{1}\x0F {2} {3} on {4} with \x0307{5}\x0F achievement points and \x0307{6}\x0F honourable kills. Armoury Profile: {7}' \
                 .format(data['name'], data['level'], wow_get_gender(data['gender']), wow_get_class(data['class'], True), data['realm'], 
-                data['achievementPoints'], data['totalHonorableKills'], web.isgd(niceurl))
+                    data['achievementPoints'], data['totalHonorableKills'], web.isgd(niceurl))
         except Exception as e:
-            return 'An error occured within the API request for {}, error: {}'.format(link, str(e))
+			return 'Unable to fetch information for {}. Does the realm or character exist? ({})'.format(niceurl, str(e))
             
     return 'An unexpected error occured.'
     
@@ -97,11 +97,18 @@ def wow_get_gender(genderid):
 def wow_get_class(classid, colours = False):
     """Formats a class ID to a readable name, data from http://eu.battle.net/api/wow/data/character/classes"""
     if colours:
-        classids = {1: "\x0305Warrior\x0F", 2: "\x0313Paladin\x0F", 3: "\x0303Hunter\x0F", 4: "\x0308Rogue\x0F", 5: "Priest", 6: "\x0304Death Knight\x0F", 
-            7: "\x0310Shaman\x0F", 8: "\x0311Mage\x0F", 9: "\x0306Warlock\x0F", 10: "\x0309Monk\x0F", 11: "\x0307Druid\x0F"}
+		# Format their colours according to class colours.
+        classids = {
+            1: "\x0305Warrior\x0F", 2: "\x0313Paladin\x0F", 3: "\x0303Hunter\x0F", 4: "\x0308Rogue\x0F", 
+            5: "Priest", 6: "\x0304Death Knight\x0F", 7: "\x0310Shaman\x0F", 8: "\x0311Mage\x0F", 
+            9: "\x0306Warlock\x0F", 10: "\x0309Monk\x0F", 11: "\x0307Druid\x0F"
+        }
     else:
-        classids = {1: "Warrior", 2: "Paladin", 3: "Hunter", 4: "Rogue", 5: "Priest", 6: "Death Knight", 7: "Shaman",
-            8: "Mage", 9: "Warlock", 10: "Monk", 11: "Druid"}
+        classids = {
+            1: "Warrior", 2: "Paladin", 3: "Hunter", 4: "Rogue", 5: "Priest", 
+            6: "Death Knight", 7: "Shaman", 8: "Mage", 9: "Warlock", 10: "Monk", 
+            11: "Druid"
+        }
         
             
     if classid in classids:
@@ -111,9 +118,11 @@ def wow_get_class(classid, colours = False):
         
 def wow_get_race(raceid):
     """Formats a race ID to a readable race name, data from http://eu.battle.net/api/wow/data/character/races"""
-    raceids = {1: "Human", 2: "Orc", 3: "Dwarf", 4: "Night Elf", 5: "Undead", 6: "Tauren", 7: "Gnome", 
-        8: "Troll", 9: "Goblin", 10: "Blood Elf", 11: "Draenei", 22: "Worgen", 24: "Pandaren (neutral)", 
-        25: "Pandaren (alliance)", 26: "Pandaren (horde)"}
+    raceids = {
+        1: "Human", 2: "Orc", 3: "Dwarf", 4: "Night Elf", 5: "Undead", 6: "Tauren", 7: "Gnome", 
+        8: "Troll", 9: "Goblin", 10: "Blood Elf", 11: "Draenei", 22: "Worgen", 
+        24: "Pandaren (neutral)", 25: "Pandaren (alliance)", 26: "Pandaren (horde)"
+    }
 
     if raceid in raceids:
         return raceids[raceid]
@@ -122,8 +131,13 @@ def wow_get_race(raceid):
     
 def wow_region_shortname(region):
     """Returns a short region name, which functions as battle.net their subdomain (i.e. eu.battle.net)"""
-    validregions = {'eu': 'eu', 'europe': 'eu', 'us': 'us', 'sea': 'sea', 'asia': 'sea', 'kr': 'kr', 'korea': 'kr',
-        'tw': 'tw', 'taiwan': 'tw'}
+    validregions = {
+        'eu': 'eu', 'europe': 'eu', 
+        'us': 'us', 
+        'sea': 'sea', 'asia': 'sea', 
+        'kr': 'kr', 'korea': 'kr',
+        'tw': 'tw', 'taiwan': 'tw'
+    }
 
     if region in validregions:
         return validregions[region]

--- a/plugins/wow.py
+++ b/plugins/wow.py
@@ -40,7 +40,7 @@ def armoury(inp):
         return 'The character name is not a valid name. Character names can only contain letters, special characters, and be 18 characters long.'
     
     if not re.match(r"^[a-z' _-]{3,32}$", realm):
-		# Realm names can have spaces in them, use dashes for this.
+        # Realm names can have spaces in them, use dashes for this.
         return 'The realm name is not a valid name. Realm names can only contain letters, dashes, and apostrophes, up to 32 characters'
     
     region_short = wow_region_shortname(region)
@@ -79,7 +79,7 @@ def wow_armoury_format(data, link):
                 .format(data['name'], data['level'], wow_get_gender(data['gender']), wow_get_class(data['class'], True), data['realm'], 
                     data['achievementPoints'], data['totalHonorableKills'], web.isgd(niceurl))
         except Exception as e:
-			return 'Unable to fetch information for {}. Does the realm or character exist? ({})'.format(niceurl, str(e))
+            return 'Unable to fetch information for {}. Does the realm or character exist? ({})'.format(niceurl, str(e))
             
     return 'An unexpected error occured.'
     
@@ -97,7 +97,7 @@ def wow_get_gender(genderid):
 def wow_get_class(classid, colours = False):
     """Formats a class ID to a readable name, data from http://eu.battle.net/api/wow/data/character/classes"""
     if colours:
-		# Format their colours according to class colours.
+        # Format their colours according to class colours.
         classids = {
             1: "\x0305Warrior\x0F", 2: "\x0313Paladin\x0F", 3: "\x0303Hunter\x0F", 4: "\x0308Rogue\x0F", 
             5: "Priest", 6: "\x0304Death Knight\x0F", 7: "\x0310Shaman\x0F", 8: "\x0311Mage\x0F", 

--- a/plugins/wow.py
+++ b/plugins/wow.py
@@ -1,5 +1,5 @@
 """
-wow.py: 
+wow.py:
 Written by Zarthus <zarthus@zarth.us> May 30, 2014.
 Gets data from the World of Warcraft Armoury API
 
@@ -7,7 +7,7 @@ Commands:
 armoury, armory: Request data from the armoury API and format it into something human readable.
 """
 
-import re 
+import re
 import json
 from util import hook, http, web
 
@@ -21,7 +21,7 @@ def armoury(inp):
 
     if len(splitinput) < 2:
         return 'armoury [realm] [character name] [region = EU] - Look up character and returns API data.'
-    
+
     realm = splitinput[0].replace('_', '-')
     charname = splitinput[1]
 
@@ -30,97 +30,97 @@ def armoury(inp):
         region = 'eu'
     else:
         region = splitinput[2]
-            
+
     if not re.match(r"^[a-z]{1,3}$", region):
         return 'The region specified is not a valid region. Valid regions: eu, us, sea, kr, tw.'
 
-    if re.match(r"^[^\d]$", charname) or len(charname) > 18: 
-        # May not contain digits, repeat the same letter three times, or contain non-word characters. 
-        # Special characters are permitted, such as áéíóßø. 
+    if re.match(r"^[^\d]$", charname) or len(charname) > 18:
+        # May not contain digits, repeat the same letter three times, or contain non-word characters.
+        # Special characters are permitted, such as áéíóßø.
         return 'The character name is not a valid name. Character names can only contain letters, special characters, and be 18 characters long.'
-    
+
     if not re.match(r"^[a-z' _-]{3,32}$", realm):
         # Realm names can have spaces in them, use dashes for this.
         return 'The realm name is not a valid name. Realm names can only contain letters, dashes, and apostrophes, up to 32 characters'
-    
+
     region_short = wow_region_shortname(region)
 
     if not region_short:
         return 'The region \'{}\' does not exist.'.format(region)
 
     link = "http://{0}.battle.net/api/wow/character/{1}/{2}".format(region, realm, charname)
-    
+
     return wow_armoury_data(link)
-        
+
 def wow_armoury_data(link):
     """Sends the API request, and returns the data accordingly (in json if raw, nicely formatted if not)."""
-    try:    
+    try:
         data = http.get_json(link)
     except Exception as e:
         return 'Unable to fetch information for {}. Does the realm or character exist? ({})'.format(link, str(e))
-        
+
     return wow_armoury_format(data, link)
 
 def wow_armoury_format(data, link):
     """Format armoury data into a human readable string"""
 
-    if len(data) == 0: 
+    if len(data) == 0:
         return 'Could not find any results.'
-        
+
     if 'reason' in data:
         # Something went wrong (i.e. realm does not exist, character does not exist, or page not found).
         return data['reason']
-        
+
     if 'name' in data:
         niceurl = link.replace('/api/wow/', '/wow/en/') + '/simple'
 
         try:
             return '{0} is a level \x0307{1}\x0F {2} {3} on {4} with \x0307{5}\x0F achievement points and \x0307{6}\x0F honourable kills. Armoury Profile: {7}' \
-                .format(data['name'], data['level'], wow_get_gender(data['gender']), wow_get_class(data['class'], True), data['realm'], 
+                .format(data['name'], data['level'], wow_get_gender(data['gender']), wow_get_class(data['class'], True), data['realm'],
                     data['achievementPoints'], data['totalHonorableKills'], web.isgd(niceurl))
         except Exception as e:
             return 'Unable to fetch information for {}. Does the realm or character exist? ({})'.format(niceurl, str(e))
-            
+
     return 'An unexpected error occured.'
-    
+
 def wow_get_gender(genderid):
-    """Formats a gender ID to a readable gender name""" 
+    """Formats a gender ID to a readable gender name"""
     gender = 'unknown'
 
     if genderid == 0:
         gender = 'male'
-    elif genderid == 1: 
+    elif genderid == 1:
         gender = 'female'
 
     return gender
-        
+
 def wow_get_class(classid, colours = False):
     """Formats a class ID to a readable name, data from http://eu.battle.net/api/wow/data/character/classes"""
     if colours:
         # Format their colours according to class colours.
         classids = {
-            1: "\x0305Warrior\x0F", 2: "\x0313Paladin\x0F", 3: "\x0303Hunter\x0F", 4: "\x0308Rogue\x0F", 
-            5: "Priest", 6: "\x0304Death Knight\x0F", 7: "\x0310Shaman\x0F", 8: "\x0311Mage\x0F", 
+            1: "\x0305Warrior\x0F", 2: "\x0313Paladin\x0F", 3: "\x0303Hunter\x0F", 4: "\x0308Rogue\x0F",
+            5: "Priest", 6: "\x0304Death Knight\x0F", 7: "\x0310Shaman\x0F", 8: "\x0311Mage\x0F",
             9: "\x0306Warlock\x0F", 10: "\x0309Monk\x0F", 11: "\x0307Druid\x0F"
         }
     else:
         classids = {
-            1: "Warrior", 2: "Paladin", 3: "Hunter", 4: "Rogue", 5: "Priest", 
-            6: "Death Knight", 7: "Shaman", 8: "Mage", 9: "Warlock", 10: "Monk", 
+            1: "Warrior", 2: "Paladin", 3: "Hunter", 4: "Rogue", 5: "Priest",
+            6: "Death Knight", 7: "Shaman", 8: "Mage", 9: "Warlock", 10: "Monk",
             11: "Druid"
         }
-        
-            
+
+
     if classid in classids:
         return classids[classid]
     else:
-        return 'unknown'    
-        
+        return 'unknown'
+
 def wow_get_race(raceid):
     """Formats a race ID to a readable race name, data from http://eu.battle.net/api/wow/data/character/races"""
     raceids = {
-        1: "Human", 2: "Orc", 3: "Dwarf", 4: "Night Elf", 5: "Undead", 6: "Tauren", 7: "Gnome", 
-        8: "Troll", 9: "Goblin", 10: "Blood Elf", 11: "Draenei", 22: "Worgen", 
+        1: "Human", 2: "Orc", 3: "Dwarf", 4: "Night Elf", 5: "Undead", 6: "Tauren", 7: "Gnome",
+        8: "Troll", 9: "Goblin", 10: "Blood Elf", 11: "Draenei", 22: "Worgen",
         24: "Pandaren (neutral)", 25: "Pandaren (alliance)", 26: "Pandaren (horde)"
     }
 
@@ -128,13 +128,13 @@ def wow_get_race(raceid):
         return raceids[raceid]
     else:
         return 'unknown'
-    
+
 def wow_region_shortname(region):
     """Returns a short region name, which functions as battle.net their subdomain (i.e. eu.battle.net)"""
     validregions = {
-        'eu': 'eu', 'europe': 'eu', 
-        'us': 'us', 
-        'sea': 'sea', 'asia': 'sea', 
+        'eu': 'eu', 'europe': 'eu',
+        'us': 'us',
+        'sea': 'sea', 'asia': 'sea',
         'kr': 'kr', 'korea': 'kr',
         'tw': 'tw', 'taiwan': 'tw'
     }

--- a/plugins/wow.py
+++ b/plugins/wow.py
@@ -8,7 +8,7 @@ armoury, armory: Request data from the armoury API and format it into something 
 """
 
 import re
-import json
+import requests
 from util import hook, http, web
 
 @hook.command('armory')
@@ -55,7 +55,7 @@ def armoury(inp):
 def wow_armoury_data(link):
     """Sends the API request, and returns the data accordingly (in json if raw, nicely formatted if not)."""
     try:
-        data = http.get_json(link)
+        data = requests.get(link)
     except Exception as e:
         return 'Unable to fetch information for {}. Does the realm or character exist? ({})'.format(link, str(e))
 
@@ -63,6 +63,15 @@ def wow_armoury_data(link):
 
 def wow_armoury_format(data, link):
     """Format armoury data into a human readable string"""
+
+    if data.status_code != 200 and data.status_code != 404:
+        # The page returns 404 if the character or realm is not found.
+        try:
+            data.raise_for_status()
+        except Exception as e:
+            return 'An error occured while trying to fetch the data. ({})'.format(str(e))
+
+    data = data.json()
 
     if len(data) == 0:
         return 'Could not find any results.'


### PR DESCRIPTION
I'm planning to extend on this later on, but for now, this command works as is. It's very basic but does what it needs to do, as the API (and game) is rather big, and has a lot you can retrieve data from.

For now, all we fetch is: `Name`, `Level`, `Gender`, `Class`, `Realm`, `Achievement Points`, `Honourable Kills`.

Syntax: `.armoury [realm] [character name] [region = eu]`,  also supports the American spelling `.armory`
`Realm`: Any realm from any (supported) region. You'll have to specify the region if it is not Europe. Use dashes or underscores if your realm contains a space.  
`Character name`: Name of your character, it can be any unicode name, but may not be longer than 18 characters, or contain digits.  
`Region`: By default Europe, supported regions are `eu (Europe)`, `us (United States)`, `sea (South East Asia)`, `kr (Korea)`, `tw (Taiwan)`, which should cover all of them.

An example message string by `.armoury` is:

```
(19:03:40) <Zarthus> .armoury stormrage zarthus  
(19:03:41) <cloudthus> (Zarthus) Zarthus is a level 90 female Death Knight on Stormrage with 5515 achievement points and 124 honourable kills. Armoury Profile: http://is.gd/opjtNZ

(19:48:14) <@Zarthus> .armoury borean_tundra shuliay us
(19:48:15) <cloudthus> (Zarthus) Shuliay is a level 90 female Shaman on Borean Tundra with 9410 achievement points and 4646 honourable kills. Armoury Profile: http://is.gd/kGbYmh

(10:00:01) <@Zarthus> .armoury hueheuh xx
(10:00:01) <cloudthus> (Zarthus) Realm not found.

(10:00:08) <@Zarthus> .armoury stormrage xxxxtuhs
(10:00:08) <cloudthus> (Zarthus) Character not found.
```

[Visual Representation](http://i.imgur.com/fKm0eZU.png), [Second Visual Representation](http://i.imgur.com/OjoRUAB.png)

It's been tested, but I'm still very much new to Python, so there may be certain optimizations that I skipped over. I'm open to critique.
