### PR TITLE
use proper sed-like syntax for corrections, including regexes, backreferences and a few flags

### DIFF
--- a/plugins/correction.py
+++ b/plugins/correction.py
@@ -1,40 +1,28 @@
-from util import hook
-
 import re
 
-CORRECTION_RE = r'^(s|S)/.*/.*/?\S*$'
+from util import hook
+
+correction_s = r"^[sS]/(.*/.*/([igux]{,4}))\S*$"
+correction_re = re.compile(correction_s)
 
 
-@hook.regex(CORRECTION_RE)
+@hook.regex(correction_s)
 def correction(match, input=None, conn=None, message=None):
-    split = input.msg.split("/")
-
-    if len(split) == 4:
-        nick = split[3].lower()
-    else:
-        nick = None
-
-    find = split[1]
-    replace = split[2]
-
-    if not find and not find.isspace():
-        return u"Find must not be blank."
+    find, replacement, flags = tuple([b.replace("\/", "/") for b in re.split(r"(?<!\\)/", match.groups()[0])])
+    flag_string = flags.replace("g", "")
+    flag_string = "(?{})".format(flag_string) if flag_string != "" else ""
+    find_re = re.compile("{}{}".format(flag_string, find))
 
     for item in conn.history[input.chan].__reversed__():
-        name, timestamp, msg = item
-        if msg.startswith("s/"):
+        nick, timestamp, msg = item
+        if correction_re.match(msg):
             # don't correct corrections, it gets really confusing
             continue
-        if nick:
-            if nick != name.lower():
-                continue
-        if find in msg:
+        if find_re.search(msg):
             if "\x01ACTION" in msg:
                 msg = msg.replace("\x01ACTION ", "/me ").replace("\x01", "")
-            message(u"Correction, <{}> {}".format(name, msg.replace(find, "\x02" + replace + "\x02")))
+            message(u"Correction, <{}> {}".format(nick, find_re.sub("\x02" + replacement + "\x02", msg, count=int("g" not in flags))))
             return
         else:
             continue
-
-    return u"Did not find {} in any recent messages.".format(find)
-
+    return "Did not find {} in any recent messages.".format(to_find)


### PR DESCRIPTION
We support flags `igux`, backreferences `/1` work, and regexes are matched.

This looks very refactored because it was simply ported back from `CloudBotIRC`/`CloudBotRefresh` - in case anyone wanted the plugin.
